### PR TITLE
fix issue: cannot deselect index (when call [setSelectedSegmentIndex:-1]...

### DIFF
--- a/URBSegmentedControl.m
+++ b/URBSegmentedControl.m
@@ -318,6 +318,7 @@ static CGSize const kURBDefaultSize = {300.0f, 44.0f};
 }
 
 - (void)setEnabled:(BOOL)enabled forSegmentAtIndex:(NSUInteger)segment {
+	[super setEnabled:enabled forSegmentAtIndex:segment];
 	[self segmentAtIndex:segment].enabled = enabled;
 }
 


### PR DESCRIPTION
This issue is when want to unselect segemntedControl.
I want call [URBSegmentedControl setSelectedSegmentIndex:-1];

and
- fix issue when init from nib. at [initWithCoder:]
- fix illegally value-changed event, when tap disabled segment at [setEnabled:forSegmentAtIndex:]
